### PR TITLE
Add range parameter and fix query parameters in download methods

### DIFF
--- a/aiob2/bucket.py
+++ b/aiob2/bucket.py
@@ -229,6 +229,7 @@ class Client:
         self,
         file_id: str,
         *,
+        range_: Optional[str] = None,
         content_disposition: Optional[str] = None,
         content_language: Optional[str] = None,
         expires: Optional[str] = None,
@@ -243,6 +244,10 @@ class Client:
         -----------
         file_id: :class:`str`
             The file id of the file to be downloaded.
+        range_: Optional[:class:`str`]
+            A standard byte-range request, which will return just part of the stored file. For
+            example, "bytes=0,99" selects bytes 0 through 99 (inclusive) of the file, so it will
+            return the first 100 bytes.
         content_disposition: Optional[:class:`str`]
             Overrides the current 'b2-content-disposition' specified when the file was uploaded.
         content_language: Optional[:class:`str`]
@@ -267,6 +272,7 @@ class Client:
 
         data = await self._http.download_file_by_id(
             file_id=file_id,
+            range_=range_,
             content_disposition=content_disposition,
             content_language=content_language,
             expires=expires,
@@ -282,6 +288,7 @@ class Client:
         file_name: str,
         bucket_name: str,
         *,
+        range_: Optional[str] = None,
         content_disposition: Optional[str] = None,
         content_language: Optional[str] = None,
         expires: Optional[str] = None,
@@ -299,6 +306,10 @@ class Client:
         bucket_name: :class:`str`
             The bucket name of the file to be downloaded. This should only be specified if you have specified
             file_name and not file_id.
+        range_: Optional[:class:`str`]
+            A standard byte-range request, which will return just part of the stored file. For
+            example, "bytes=0,99" selects bytes 0 through 99 (inclusive) of the file, so it will
+            return the first 100 bytes.
         content_disposition: Optional[:class:`str`]
             Overrides the current 'b2-content-disposition' specified when the file was uploaded.
         content_language: Optional[:class:`str`]
@@ -324,6 +335,7 @@ class Client:
         data = await self._http.download_file_by_name(
             file_name=file_name,
             bucket_name=bucket_name,
+            range_=range_,
             content_disposition=content_disposition,
             content_language=content_language,
             expires=expires,

--- a/tests/test_download.py
+++ b/tests/test_download.py
@@ -36,3 +36,85 @@ class TestDownload:
         assert downloaded_file.content == path.read_bytes()
 
         await client.close()
+
+    @pytest.mark.asyncio
+    @pytest.mark.order(2)
+    async def test_download_range(self):
+        client = Client(os.environ['KEY_ID'], os.environ['KEY'], log_level=logging.DEBUG)
+        file = ValueStorage.test_upload_file
+        assert isinstance(file, File)
+
+        range_length = 100
+        range_str = f"bytes=0-{range_length - 1}"
+
+        downloaded_file = await client.download_file_by_name(
+            file_name=file.name,
+            bucket_name=os.environ['BUCKET_NAME'],
+            range_=range_str
+        )
+
+        assert downloaded_file.name == file.name
+        assert downloaded_file.id == file.id
+        assert len(downloaded_file.content) <= range_length
+        assert int(downloaded_file.content_length) <= range_length
+        assert int(downloaded_file.content_length) == len(downloaded_file.content)
+
+        # Download (by id)
+
+        downloaded_file = await client.download_file_by_id(file_id=file.id, range_=range_str)
+
+        assert downloaded_file.name == file.name
+        assert downloaded_file.id == file.id
+        assert len(downloaded_file.content) <= range_length
+        assert int(downloaded_file.content_length) <= range_length
+        assert int(downloaded_file.content_length) == len(downloaded_file.content)
+
+        await client.close()
+
+    @pytest.mark.asyncio
+    @pytest.mark.order(2)
+    async def test_download_params(self):
+        client = Client(os.environ['KEY_ID'], os.environ['KEY'], log_level=logging.DEBUG)
+        file = ValueStorage.test_upload_file
+        assert isinstance(file, File)
+
+        content_disposition = f'attachment; filename="filename.jpg"'
+        content_language = 'de-DE'
+        expires = 'Wed, 21 Oct 2015 07:28:00 GMT'
+        # TODO: this is a valid value for cache-control, but DownloadedFile tries to parse it as a timestamp
+        # cache_control = 'max-age=604800, must-revalidate'
+        content_encoding = 'compress'
+        content_type = 'text/html;charset=utf-8'
+
+        downloaded_file = await client.download_file_by_name(
+            file_name=file.name,
+            bucket_name=os.environ['BUCKET_NAME'],
+            content_disposition=content_disposition,
+            content_language=content_language,
+            expires=expires,
+            # cache_control=cache_control,
+            content_encoding=content_encoding,
+            content_type=content_type
+        )
+
+        assert downloaded_file.name == file.name
+        assert downloaded_file.id == file.id
+        assert downloaded_file.content == path.read_bytes()
+        assert downloaded_file.content_disposition == content_disposition
+        assert downloaded_file.content_language == content_language
+        # TODO: cache-control header is not exposed by DownloadedFile, and the logic that sets expires needs some
+        #       attention
+        # assert downloaded_file.cache_control == cache_control
+        # assert downloaded_file.expires == expires
+        assert downloaded_file.content_encoding == content_encoding
+        assert downloaded_file.content_type == content_type
+
+        # Download (by id)
+
+        downloaded_file = await client.download_file_by_id(file_id=file.id)
+
+        assert downloaded_file.name == file.name
+        assert downloaded_file.id == file.id
+        assert downloaded_file.content == path.read_bytes()
+
+        await client.close()


### PR DESCRIPTION
Added: New range parameter (range_ in code to avoid collision with Python built-in function) in download methods; passed to B2 API as an HTTP header.

Fixed: Parameters that were passed as headers (content_disposition, content_language etc) should have been query parameters on the URL.

Added: Test methods to test the above.